### PR TITLE
replace usage of  getfuncargvalue with getfixturevalue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+unreleased
+-------
+
+- [feature] - migrate usage of getfuncargvalue to getfixturevalue. require at least pytest 3.0.0
+
 1.0.0
 -------
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
- # We must not use the mongo plugin in its tests.
 addopts = --max-slave-restart=0 --showlocals --verbose

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ def read(fname):
     return open(os.path.join(here, fname)).read()
 
 requirements = [
-    'pytest',
+    'pytest>=3.0.0',
     'pymongo',
     'path.py>=6.2',
     'mirakuru',

--- a/src/pytest_mongo/factories.py
+++ b/src/pytest_mongo/factories.py
@@ -133,7 +133,7 @@ def mongodb(process_fixture_name):
         :rtype: pymongo.connection.Connection
         :returns: connection to mongo database
         """
-        mongodb_process = request.getfuncargvalue(process_fixture_name)
+        mongodb_process = request.getfixturevalue(process_fixture_name)
         if not mongodb_process.running():
             mongodb_process.start()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,8 @@
-"""Importing plugin in conftest to gather proper coverage."""
+"""Tests main conftest file."""
+import sys
+import warnings
+
+major, minor = sys.version_info[:2]
+
+if not (major >= 3 and minor >= 5):
+    warnings.simplefilter("error", category=DeprecationWarning)

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -1,5 +1,5 @@
 """pytest-mongo tests collection."""
-from path import path
+from path import Path
 
 from pytest_mongo import factories
 
@@ -11,7 +11,7 @@ def test_mongo(mongodb):
     }
 
     db = mongodb['test_db']
-    db.test.insert(test_data)
+    db.test.insert_one(test_data)
     assert db.test.find_one()['test1'] == 'test1'
 
 
@@ -30,28 +30,28 @@ def test_third_mongo(mongodb, mongodb2, mongodb3):
         "test1": "test1",
     }
     db = mongodb['test_db']
-    db.test.insert(test_data_one)
+    db.test.insert_one(test_data_one)
     assert db.test.find_one()['test1'] == 'test1'
 
     test_data_two = {
         "test2": "test2",
     }
     db = mongodb2['test_db']
-    db.test.insert(test_data_two)
+    db.test.insert_one(test_data_two)
     assert db.test.find_one()['test2'] == 'test2'
 
     test_data_three = {
         "test3": "test3",
     }
     db = mongodb3['test_db']
-    db.test.insert(test_data_three)
+    db.test.insert_one(test_data_three)
     assert db.test.find_one()['test3'] == 'test3'
 
 
 def test_mongo_proc(mongo_proc, mongo_proc2, mongo_proc3):
     """Several mongodb processes running."""
     for m in (mongo_proc, mongo_proc2, mongo_proc3):
-        assert path('/tmp/mongo.{port}.log'.format(port=m.port)).isfile()
+        assert Path('/tmp/mongo.{port}.log'.format(port=m.port)).isfile()
 
 
 mongo_proc_rand = factories.mongo_proc(port=None, params=mongo_params)


### PR DESCRIPTION
- make pytest 3.0.0 a minimum requirement

- throw an error in own tests on deprecation warning.