### PR TITLE
add timeout to executor running mongo

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+unreleased
+-------
+
+- [enhancements] set executor timeout to 60. By default mirakuru waits indefinitely, which might cause test hangs
+
 1.1.0
 -------
 

--- a/src/pytest_mongo/factories.py
+++ b/src/pytest_mongo/factories.py
@@ -106,6 +106,7 @@ def mongo_proc(
             ),
             host=mongo_host,
             port=mongo_port,
+            timeout=60
         )
         mongo_executor.start()
 


### PR DESCRIPTION
- should prevent any hangs, and is a return to practice from dbfixtures