### PR TITLE
Add Mongo 8 to tests

### DIFF
--- a/.github/workflows/single-mongo.yml
+++ b/.github/workflows/single-mongo.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       python-versions:
         description: 'Supported python versions'
-        default: '["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9"]'
+        default: '["3.9", "3.10", "3.11", "3.12", "pypy-3.10"]'
         required: false
         type: string
       mongo:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,13 +7,21 @@ on:
     branches: [ main ]
 
 jobs:
+  mongo_8:
+    uses: ./.github/workflows/single-mongo.yml
+    with:
+      mongo: 8.0
   mongo_7:
+    needs: [mongo_8]
     uses: ./.github/workflows/single-mongo.yml
     with:
       mongo: 7.0
+      os: ubuntu-22.04
+      python-versions: '["3.9", "3.10", "3.11", "3.12"]'
   mongo_6:
-#    needs: [mongo_7]
+    needs: [mongo_8]
     uses: ./.github/workflows/single-mongo.yml
     with:
       mongo: 6.0
-      python-versions: '["3.9", "3.10", "3.11", "3.12"]'
+      os: ubuntu-22.04
+      python-versions: '["3.11", "3.12"]'

--- a/newsfragments/+47515354.misc.rst
+++ b/newsfragments/+47515354.misc.rst
@@ -1,0 +1,1 @@
+Add MongoDB 8.0 support to CI

--- a/newsfragments/+97b07511.break.rst
+++ b/newsfragments/+97b07511.break.rst
@@ -1,0 +1,1 @@
+Dropped Python 3.8 from CI and support

--- a/newsfragments/+dcba99be.misc.rst
+++ b/newsfragments/+dcba99be.misc.rst
@@ -1,0 +1,1 @@
+Pin OS to Ubuntu 22.04 for Mongo 7 and 6 tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -33,7 +32,7 @@ dependencies = [
     "mirakuru",
     "pymongo",
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 
 [project.urls]
 "Source" = "https://github.com/ClearcodeHQ/pytest-mongo"


### PR DESCRIPTION
* run mongo 7and 6 tests on Ubuntu 22.04

Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number