### PR TITLE
Drop MongoDB 6 from CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,3 @@ jobs:
       mongo: 7.0
       os: ubuntu-22.04
       python-versions: '["3.9", "3.10", "3.11", "3.12", "3.13"]'
-  mongo_6:
-    needs: [mongo_8]
-    uses: ./.github/workflows/single-mongo.yml
-    with:
-      mongo: 6.0
-      os: ubuntu-22.04
-      python-versions: '["3.12", "3.13"]'

--- a/newsfragments/+a6a9e78e.misc.rst
+++ b/newsfragments/+a6a9e78e.misc.rst
@@ -1,0 +1,1 @@
+Drop MongoDB 6 from CI


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed MongoDB 6 from the continuous integration testing suite. The CI pipeline now covers only MongoDB 7 and MongoDB 8 releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->