### PR TITLE
Replace black with ruff-format - closes #728

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,17 +22,12 @@ repos:
       - id: detect-private-key
       - id: debug-statements
 
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.1.0
-    hooks:
-      - id: black
-        entry: black --config pyproject.toml .
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.14
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix, --respect-gitignore, --show-fixes]
+      - id: ruff-format
 
   - repo: https://github.com/rstcheck/rstcheck
     rev: v6.2.5

--- a/newsfragments/728.misc.rst
+++ b/newsfragments/728.misc.rst
@@ -1,0 +1,3 @@
+Replace black with ruff-format.
+
+Should speed pre-commit up.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,13 +60,11 @@ strict_xfail=true
 addopts = ["--showlocals", "--verbose", "--cov"]
 testpaths = ["tests"]
 
-[tool.black]
-line-length = 80
-target-version = ['py310']
-include = '.*\.pyi?$'
-
 [tool.ruff]
-line-length = 80
+line-length = 100
+target-version = 'py310'
+
+[tool.ruff.lint]
 select = [
     "E",   # pycodestyle
     "F",   # pyflakes

--- a/pytest_mongo/factories.py
+++ b/pytest_mongo/factories.py
@@ -151,17 +151,13 @@ def mongodb(
         mongo_tz_aware = False
         if tz_aware is not None:
             mongo_tz_aware = tz_aware
-        elif config["tz_aware"] is not None and isinstance(
-            config["tz_aware"], bool
-        ):
+        elif config["tz_aware"] is not None and isinstance(config["tz_aware"], bool):
             mongo_tz_aware = config["tz_aware"]
 
         mongo_host = mongodb_process.host
         mongo_port = mongodb_process.port
 
-        mongo_conn: MongoClient = MongoClient(
-            mongo_host, mongo_port, tz_aware=mongo_tz_aware
-        )
+        mongo_conn: MongoClient = MongoClient(mongo_host, mongo_port, tz_aware=mongo_tz_aware)
 
         yield mongo_conn
 

--- a/pytest_mongo/plugin.py
+++ b/pytest_mongo/plugin.py
@@ -35,15 +35,11 @@ _help_tz_aware = "Have mongo client timezone aware"
 
 def pytest_addoption(parser: Parser) -> None:
     """Configure pytest-mongo configuration options."""
-    parser.addini(
-        name="mongo_exec", help=_help_executable, default="/usr/bin/mongod"
-    )
+    parser.addini(name="mongo_exec", help=_help_executable, default="/usr/bin/mongod")
 
     parser.addini(name="mongo_params", help=_help_params, default="")
 
-    parser.addini(
-        name="mongo_logsdir", help=_help_logsdir, default=gettempdir()
-    )
+    parser.addini(name="mongo_logsdir", help=_help_logsdir, default=gettempdir())
 
     parser.addini(name="mongo_host", help=_help_host, default="127.0.0.1")
 
@@ -68,9 +64,7 @@ def pytest_addoption(parser: Parser) -> None:
         help=_help_executable,
     )
 
-    parser.addoption(
-        "--mongo-params", action="store", dest="mongo_params", help=_help_params
-    )
+    parser.addoption("--mongo-params", action="store", dest="mongo_params", help=_help_params)
 
     parser.addoption(
         "--mongo-logsdir",
@@ -87,9 +81,7 @@ def pytest_addoption(parser: Parser) -> None:
         help=_help_host,
     )
 
-    parser.addoption(
-        "--mongo-port", action="store", dest="mongo_port", help=_help_port
-    )
+    parser.addoption("--mongo-port", action="store", dest="mongo_port", help=_help_port)
 
     parser.addoption(
         "--mongo-tz-aware",

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -17,9 +17,7 @@ def test_mongo(mongodb: MongoClient) -> None:
     assert database.test.find_one()["test1"] == "test1"  # type: ignore
 
 
-def test_third_mongo(
-    mongodb: MongoClient, mongodb2: MongoClient, mongodb3: MongoClient
-) -> None:
+def test_third_mongo(mongodb: MongoClient, mongodb2: MongoClient, mongodb3: MongoClient) -> None:
     """Test with everal mongo processes and connections."""
     test_data_one = {
         "test1": "test1",

--- a/tests/test_noopexecutor.py
+++ b/tests/test_noopexecutor.py
@@ -9,9 +9,7 @@ from pytest_mongo.executor_noop import NoopExecutor
 def test_nooproc_version(mongo_proc: TCPExecutor) -> None:
     """Test the way mongo version is being read."""
     mongo_nooproc = NoopExecutor(mongo_proc.host, mongo_proc.port)
-    proc_client: MongoClient = MongoClient(
-        host=mongo_proc.host, port=mongo_proc.port
-    )
+    proc_client: MongoClient = MongoClient(host=mongo_proc.host, port=mongo_proc.port)
     assert proc_client.server_info()["version"] == mongo_nooproc.version
 
 


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Replaced the Black pre-commit hook with Ruff (separate check and format hooks) to streamline formatting and speed up pre-commit runs.
  - Increased maximum line length to 100 and refined Ruff configuration (including isort and docstring linting).

- Style
  - Reformatted code and tests for consistency using Ruff; no functional changes.

- Documentation
  - Added a news entry noting the switch to Ruff formatting and expected pre-commit performance improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->