### PR TITLE
Remove Mongo's dbpath only if it exists at the end of proc fixture - …

### DIFF
--- a/newsfragments/725.bugfix.rst
+++ b/newsfragments/725.bugfix.rst
@@ -1,0 +1,1 @@
+Remove Mongo's DBpath only after checking for its existence at the end of the proc fixture.

--- a/pytest_mongo/factories.py
+++ b/pytest_mongo/factories.py
@@ -89,8 +89,8 @@ def mongo_proc(
         )
         with mongo_executor:
             yield mongo_executor
-        os.path.exists(mongo_db_path)
-        rmtree(mongo_db_path)
+        if os.path.exists(mongo_db_path):
+            rmtree(mongo_db_path)
 
     return mongo_proc_fixture
 


### PR DESCRIPTION
…closes #725

Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Test fixture cleanup now checks the MongoDB data directory exists before attempting removal, preventing teardown errors when the directory is absent.
  * Added a small release note clarifying the safe removal behaviour at the end of the MongoDB process fixture.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->