### PR TITLE
Run xdist tests on CI with -n auto - closes #723

### DIFF
--- a/.github/workflows/single-mongo.yml
+++ b/.github/workflows/single-mongo.yml
@@ -55,7 +55,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
-        command: pytest -n 1 --max-worker-restart=0 --cov-report=xml:coverage-xdist.xml
+        command: pytest -n auto --dist loadgroup --max-worker-restart=0 --cov-report=xml:coverage-xdist.xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5.5.2
       with:

--- a/.github/workflows/tests-oldest.yml
+++ b/.github/workflows/tests-oldest.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Run xdist test
       uses: fizyk/actions-reuse/.github/actions/pipenv-run@v4.2.1
       with:
-        command: pytest -n 1 -c pyproject.oldest.toml --max-worker-restart=0 --cov-report=xml:coverage-xdist.xml
+        command: pytest -n auto --dist loadgroup -c pyproject.oldest.toml --max-worker-restart=0 --cov-report=xml:coverage-xdist.xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5.5.2
       with:

--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,12 @@ You can pick which you prefer, but remember that these settings are handled in t
      - port
      - 27017
      - random
+   * - Port search count
+     -
+     - --mongo-port-search-count
+     - mongo_port_search_count
+     - -
+     - 5
    * - Additional parameters
      - params
      - --mongo-params

--- a/newsfragments/723.feature.rst
+++ b/newsfragments/723.feature.rst
@@ -1,0 +1,4 @@
+Improved xdist compatibility by introducing port-locking mechanism.
+
+If one worker will claim port, it will lock it, and other xdist workers will
+either check another port or raise error with clear message.

--- a/newsfragments/723.misc.rst
+++ b/newsfragments/723.misc.rst
@@ -1,0 +1,1 @@
+Run xdist tests on CI with -n auto.

--- a/pytest_mongo/config.py
+++ b/pytest_mongo/config.py
@@ -13,6 +13,7 @@ class MongoConfig:
     exec: str
     host: str
     port: int | None
+    port_search_count: int
     params: str
     tz_aware: bool
 
@@ -30,6 +31,7 @@ def get_config(request: FixtureRequest) -> MongoConfig:
         exec=get_mongo_option("exec"),
         host=get_mongo_option("host"),
         port=int(port) if port else None,
+        port_search_count=int(get_mongo_option("port_search_count")),
         params=get_mongo_option("params"),
         tz_aware=get_mongo_option("tz_aware"),
     )

--- a/pytest_mongo/plugin.py
+++ b/pytest_mongo/plugin.py
@@ -26,6 +26,7 @@ _help_executable = "Path to MongoDB executable"
 _help_params = "Additional MongoDB parameters"
 _help_host = "Host at which MongoDB will accept connections"
 _help_port = "Port at which MongoDB will accept connections"
+_help_port_search_count = "Number of times, pytest-mongo will search for free port"
 _help_tz_aware = "Have mongo client timezone aware"
 
 
@@ -42,6 +43,7 @@ def pytest_addoption(parser: Parser) -> None:
         help=_help_port,
         default=None,
     )
+    parser.addini(name="mongo_port_search_count", help=_help_port_search_count, default=5)
 
     parser.addini(
         name="mongo_tz_aware",
@@ -65,6 +67,12 @@ def pytest_addoption(parser: Parser) -> None:
         action="store",
         dest="mongo_host",
         help=_help_host,
+    )
+    parser.addoption(
+        "--mongo-port-search-count",
+        action="store",
+        dest="mongo_port_search_count",
+        help=_help_port_search_count,
     )
 
     parser.addoption("--mongo-port", action="store", dest="mongo_port", help=_help_port)

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -1,5 +1,6 @@
 """pytest-mongo tests collection."""
 
+import pytest
 from mirakuru import TCPExecutor
 from pymongo import MongoClient
 
@@ -15,6 +16,7 @@ def test_mongo(mongodb: MongoClient) -> None:
     assert database.test.find_one()["test1"] == "test1"  # type: ignore
 
 
+@pytest.mark.xdist_group(name="many_mongo")
 def test_third_mongo(mongodb: MongoClient, mongodb2: MongoClient, mongodb3: MongoClient) -> None:
     """Test with everal mongo processes and connections."""
     test_data_one = {
@@ -39,6 +41,7 @@ def test_third_mongo(mongodb: MongoClient, mongodb2: MongoClient, mongodb3: Mong
     assert database.test.find_one()["test3"] == "test3"  # type: ignore
 
 
+@pytest.mark.xdist_group(name="many_mongo")
 def test_mongo_proc(
     mongo_proc: TCPExecutor, mongo_proc2: TCPExecutor, mongo_proc3: TCPExecutor
 ) -> None:


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI test workflows now use automatic worker allocation (-n auto) with loadgroup distribution for parallel runs.
* **New Features**
  * New configuration option to control port-search attempts (INI/CLI) with a default value.
  * Tests grouped for distributed execution to coordinate parallel runs.
* **Bug Fixes**
  * Port-locking, selection and retry improvements to reduce collisions and clearer errors during concurrent tests.
* **Documentation**
  * Added docs and release notes describing the new option and behaviour.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->