### PR TITLE
Refactor tmpdir handling into using tmp_path_factory - closes #742

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,12 +108,6 @@ You can pick which you prefer, but remember that these settings are handled in t
      - port
      - 27017
      - random
-   * - Path to store logs
-     - logsdir
-     - --mongo-logsdir
-     - mongo_logsdir
-     - no
-     - $TMPDIR
    * - Additional parameters
      - params
      - --mongo-params

--- a/newsfragments/742.break.rst
+++ b/newsfragments/742.break.rst
@@ -1,0 +1,1 @@
+logsdir is no longer configurable; all temporary files are managed by tmp_path_factory.

--- a/newsfragments/742.feature.rst
+++ b/newsfragments/742.feature.rst
@@ -1,0 +1,3 @@
+Temporary files for the process are now handled by tmp_path_factory rather than tempfile.gettempdir()
+
+This will result in better test isolation and automatic cleanup.

--- a/pytest_mongo/config.py
+++ b/pytest_mongo/config.py
@@ -1,7 +1,6 @@
 """Mongo config getter."""
 
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
 
 from pytest import FixtureRequest
@@ -15,7 +14,6 @@ class MongoConfig:
     host: str
     port: int | None
     params: str
-    logsdir: Path
     tz_aware: bool
 
 
@@ -33,7 +31,6 @@ def get_config(request: FixtureRequest) -> MongoConfig:
         host=get_mongo_option("host"),
         port=int(port) if port else None,
         params=get_mongo_option("params"),
-        logsdir=Path(get_mongo_option("logsdir")),
         tz_aware=get_mongo_option("tz_aware"),
     )
     return cfg

--- a/pytest_mongo/plugin.py
+++ b/pytest_mongo/plugin.py
@@ -17,15 +17,12 @@
 # along with pytest-mongo.  If not, see <http://www.gnu.org/licenses/>.
 """Pytest-mongo plugin definition."""
 
-from tempfile import gettempdir
-
 from pytest import Parser
 
 from pytest_mongo import factories
 
 # pylint:disable=invalid-name
 _help_executable = "Path to MongoDB executable"
-_help_logsdir = "Path to logs directory"
 _help_params = "Additional MongoDB parameters"
 _help_host = "Host at which MongoDB will accept connections"
 _help_port = "Port at which MongoDB will accept connections"
@@ -37,8 +34,6 @@ def pytest_addoption(parser: Parser) -> None:
     parser.addini(name="mongo_exec", help=_help_executable, default="/usr/bin/mongod")
 
     parser.addini(name="mongo_params", help=_help_params, default="")
-
-    parser.addini(name="mongo_logsdir", help=_help_logsdir, default=gettempdir())
 
     parser.addini(name="mongo_host", help=_help_host, default="127.0.0.1")
 
@@ -64,14 +59,6 @@ def pytest_addoption(parser: Parser) -> None:
     )
 
     parser.addoption("--mongo-params", action="store", dest="mongo_params", help=_help_params)
-
-    parser.addoption(
-        "--mongo-logsdir",
-        action="store",
-        metavar="path",
-        dest="mongo_logsdir",
-        help=_help_logsdir,
-    )
 
     parser.addoption(
         "--mongo-host",

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -1,7 +1,5 @@
 """pytest-mongo tests collection."""
 
-import os
-
 from mirakuru import TCPExecutor
 from pymongo import MongoClient
 
@@ -45,8 +43,9 @@ def test_mongo_proc(
     mongo_proc: TCPExecutor, mongo_proc2: TCPExecutor, mongo_proc3: TCPExecutor
 ) -> None:
     """Several mongodb processes running."""
-    for mongo in (mongo_proc, mongo_proc2, mongo_proc3):
-        assert os.path.isfile("/tmp/mongo.{port}.log".format(port=mongo.port))
+    assert mongo_proc.running() is True
+    assert mongo_proc2.running() is True
+    assert mongo_proc3.running() is True
 
 
 def test_random_port(mongodb_rand: MongoClient) -> None:


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the logsdir configuration option; the --mongo-logsdir CLI flag and mongo_logsdir INI setting are no longer available.

* **Improvements**
  * Temporary files and logs are now managed via pytest's tmp_path_factory, improving test isolation and automatic cleanup.
  * Tests now verify process state rather than relying on log-file existence.

* **Documentation**
  * Docs and release notes updated to reflect the new temporary file handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->