### PR TITLE
Replace TypedDict-based config with dataclass-based one - closes #722

### DIFF
--- a/newsfragments/722.feature.rst
+++ b/newsfragments/722.feature.rst
@@ -1,0 +1,1 @@
+Replace TypedDict-based config with a dataclass-based config.

--- a/pytest_mongo/config.py
+++ b/pytest_mongo/config.py
@@ -1,13 +1,15 @@
 """Mongo config getter."""
 
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import Any
 
 from pytest import FixtureRequest
 
 
-class MongoConfigDict(TypedDict):
-    """Typed Config dictionary."""
+@dataclass
+class MongoConfig:
+    """Mongo config dataclass."""
 
     exec: str
     host: str
@@ -17,19 +19,21 @@ class MongoConfigDict(TypedDict):
     tz_aware: bool
 
 
-def get_config(request: FixtureRequest) -> MongoConfigDict:
-    """Return a dictionary with config options."""
+def get_config(request: FixtureRequest) -> MongoConfig:
+    """Return a MongoConfig with config options."""
 
     def get_mongo_option(option: str) -> Any:
         name = "mongo_" + option
         return request.config.getoption(name) or request.config.getini(name)
 
     port = get_mongo_option("port")
-    return MongoConfigDict(
+
+    cfg = MongoConfig(
         exec=get_mongo_option("exec"),
         host=get_mongo_option("host"),
         port=int(port) if port else None,
         params=get_mongo_option("params"),
-        logsdir=get_mongo_option("logsdir"),
+        logsdir=Path(get_mongo_option("logsdir")),
         tz_aware=get_mongo_option("tz_aware"),
     )
+    return cfg

--- a/pytest_mongo/factories/client.py
+++ b/pytest_mongo/factories/client.py
@@ -33,8 +33,8 @@ def mongodb(
         mongo_tz_aware = False
         if tz_aware is not None:
             mongo_tz_aware = tz_aware
-        elif config["tz_aware"] is not None and isinstance(config["tz_aware"], bool):
-            mongo_tz_aware = config["tz_aware"]
+        elif config.tz_aware is not None and isinstance(config.tz_aware, bool):
+            mongo_tz_aware = config.tz_aware
 
         mongo_host = mongodb_process.host
         mongo_port = mongodb_process.port

--- a/pytest_mongo/factories/noprocess.py
+++ b/pytest_mongo/factories/noprocess.py
@@ -27,8 +27,8 @@ def mongo_noproc(
         :returns: tcp executor-like object
         """
         config = get_config(request)
-        mongo_host = host or config["host"]
-        mongo_port = port or config["port"] or 27017
+        mongo_host = host or config.host
+        mongo_port = port or config.port or 27017
         assert mongo_port
 
         noop_exec = NoopExecutor(host=mongo_host, port=mongo_port)

--- a/pytest_mongo/factories/process.py
+++ b/pytest_mongo/factories/process.py
@@ -44,15 +44,15 @@ def mongo_proc(
         config = get_config(request)
         tmpdir = gettempdir()
 
-        mongo_exec = executable or config["exec"]
-        mongo_params = params or config["params"]
+        mongo_exec = executable or config.exec
+        mongo_params = params or config.params
 
-        mongo_host = host or config["host"]
+        mongo_host = host or config.host
         assert mongo_host
-        mongo_port = get_port(port) or get_port(config["port"])
+        mongo_port = get_port(port) or get_port(config.port)
         assert mongo_port
 
-        mongo_logsdir = logsdir or config["logsdir"]
+        mongo_logsdir = logsdir or config.logsdir
         mongo_logpath = os.path.join(mongo_logsdir, f"mongo.{mongo_port}.log")
         mongo_db_path = os.path.join(tmpdir, f"mongo.{mongo_port}")
         os.mkdir(mongo_db_path)


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Configuration handling migrated to a structured dataclass model for stronger typing and clearer access patterns; maintains existing behaviour and public interfaces so no user-facing changes are expected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->