### PR TITLE
Add pyproject-fmt to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,11 @@ repos:
         args: [--fix, --exit-non-zero-on-fix, --respect-gitignore, --show-fixes]
       - id: ruff-format
 
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: v2.24.1
+    hooks:
+      - id: pyproject-fmt
+
   - repo: https://github.com/rstcheck/rstcheck
     rev: v6.2.5
     hooks:

--- a/newsfragments/+pyprojectfmt.misc.rst
+++ b/newsfragments/+pyprojectfmt.misc.rst
@@ -1,0 +1,1 @@
+Add pyproject-fmt to pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,82 +1,143 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [ "setuptools>=61.0.0" ]
+
 [project]
 name = "pytest-mongo"
 version = "4.0.0"
 description = "MongoDB process and client fixtures plugin for Pytest."
 readme = "README.rst"
-keywords = ["tests", "pytest", "fixture", "mongodb", "mongo"]
-license = {file = "LICENSE"}
-authors = [
-    {name = "Grzegorz Śliwiński", email = "fizyk+pypi@fizyk.dev"}
-]
+keywords = [ "fixture", "mongo", "mongodb", "pytest", "tests" ]
+license = { file = "LICENSE" }
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
+    "Framework :: Pytest",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Testing",
-    "Framework :: Pytest",
 ]
 dependencies = [
-    "pytest >= 8.4",
-    "port-for >= 0.7.3",
-    "mirakuru >= 2.6.0",
-    "pymongo >= 4.10.0",
+    "mirakuru>=2.6.0",
+    "port-for>=0.7.3",
+    "pymongo>=4.10.0",
+    "pytest>=8.4",
 ]
-requires-python = ">= 3.10"
 
-[project.urls]
-"Source" = "https://github.com/dbfixtures/pytest-mongo"
-"Bug Tracker" = "https://github.com/dbfixtures/pytest-mongo/issues"
-"Changelog" = "https://github.com/dbfixtures/pytest-mongo/blob/v4.0.0/CHANGES.rst"
+[[project.authors]]
+name = "Grzegorz Śliwiński"
+email = "fizyk+pypi@fizyk.dev"
 
-[project.entry-points."pytest11"]
+[project.entry-points.pytest11]
 pytest_mongo = "pytest_mongo.plugin"
 
-[build-system]
-requires = ["setuptools >= 61.0.0", "wheel"]
-build-backend = "setuptools.build_meta"
+[project.urls]
+Source = "https://github.com/dbfixtures/pytest-mongo"
+"Bug Tracker" = "https://github.com/dbfixtures/pytest-mongo/issues"
+Changelog = "https://github.com/dbfixtures/pytest-mongo/blob/v4.0.0/CHANGES.rst"
 
 [tool.setuptools]
 zip-safe = true
 
 [tool.setuptools.packages.find]
-include = ["pytest_mongo*"]
-exclude = ["tests*"]
+include = [ "pytest_mongo*" ]
+exclude = [ "tests*" ]
 namespaces = false
 
-[tool.pytest]
-strict_xfail=true
-addopts = ["--showlocals", "--verbose"]
-testpaths = ["tests"]
-
 [tool.ruff]
+target-version = "py310"
 line-length = 100
-target-version = 'py310'
 
 [tool.ruff.lint]
 select = [
-    "E",   # pycodestyle
-    "F",   # pyflakes
-    "I",   # isort
-    "D",   # pydocstyle
+    "E", # pycodestyle
+    "F", # pyflakes
+    "I", # isort
+    "D", # pydocstyle
 ]
+
+# Or run some commands after the git tag and the branch
+# have been pushed:
+#  [[tool.tbump.after_push]]
+#  name = "publish"
+#  cmd = "./publish.sh"
+[tool.pyproject-fmt]
+column_width = 120
+indent = 4
+keep_full_version = true
+generate_python_version_classifiers = false
+table_format = "long"
+sub_table_spacing = "\n"
+
+[tool.pytest]
+addopts = [ "--showlocals", "--verbose" ]
+strict_xfail = true
+testpaths = [ "tests" ]
+
+# You can specify a list of commands to
+# run after the files have been patched
+# and before the git commit is made
+[[tool.tbump.before_commit]]
+name = "Build changelog"
+cmd = "pipenv run towncrier build --version {new_version} --yes"
+
+[[tool.tbump.field]]
+# the name of the field
+name = "extra"
+# the default value to use, if there is no match
+default = ""
+
+# For each file to patch, add a [[file]] config
+# section containing the path of the file, relative to the
+# tbump.toml location.
+[[tool.tbump.file]]
+src = "pytest_mongo/__init__.py"
+
+[[tool.tbump.file]]
+src = "pyproject.toml"
+search = 'version = "{current_version}"'
+
+[[tool.tbump.file]]
+src = "pyproject.toml"
+search = 'Changelog = "https://github.com/dbfixtures/pytest-mongo/blob/v{current_version}/CHANGES.rst"'
+
+[tool.tbump.git]
+message_template = "Release {new_version}"
+tag_template = "v{new_version}"
+
+[tool.tbump.version]
+current = "4.0.0"
+# Example of a semver regexp.
+# Make sure this matches current_version before
+# using tbump
+regex = '''
+  (?P<major>\d+)
+  \.
+  (?P<minor>\d+)
+  \.
+  (?P<patch>\d+)
+  (\-
+    (?P<extra>.+)
+  )?
+  '''
 
 [tool.towncrier]
 directory = "newsfragments"
-single_file=true
-filename="CHANGES.rst"
-issue_format="`#{issue} <https://github.com/dbfixtures/pytest-mongo/issues/{issue}>`__"
+filename = "CHANGES.rst"
+issue_format = "`#{issue} <https://github.com/dbfixtures/pytest-mongo/issues/{issue}>`__"
+single_file = true
 
 [[tool.towncrier.type]]
 directory = "break"
@@ -107,58 +168,3 @@ showcontent = true
 directory = "misc"
 name = "Miscellaneus"
 showcontent = true
-
-[tool.tbump.version]
-current = "4.0.0"
-
-# Example of a semver regexp.
-# Make sure this matches current_version before
-# using tbump
-regex = '''
-  (?P<major>\d+)
-  \.
-  (?P<minor>\d+)
-  \.
-  (?P<patch>\d+)
-  (\-
-    (?P<extra>.+)
-  )?
-  '''
-
-[tool.tbump.git]
-message_template = "Release {new_version}"
-tag_template = "v{new_version}"
-
-[[tool.tbump.field]]
-# the name of the field
-name = "extra"
-# the default value to use, if there is no match
-default = ""
-# For each file to patch, add a [[file]] config
-# section containing the path of the file, relative to the
-# tbump.toml location.
-
-[[tool.tbump.file]]
-src = "pytest_mongo/__init__.py"
-
-[[tool.tbump.file]]
-src = "pyproject.toml"
-search = 'version = "{current_version}"'
-
-[[tool.tbump.file]]
-src = "pyproject.toml"
-search = '"Changelog" = "https://github.com/dbfixtures/pytest-mongo/blob/v{current_version}/CHANGES.rst"'
-
-# You can specify a list of commands to
-# run after the files have been patched
-# and before the git commit is made
-
-[[tool.tbump.before_commit]]
-name = "Build changelog"
-cmd = "pipenv run towncrier build --version {new_version} --yes"
-
-# Or run some commands after the git tag and the branch
-# have been pushed:
-#  [[tool.tbump.after_push]]
-#  name = "publish"
-#  cmd = "./publish.sh"


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integrated a pre-commit hook to automatically format `pyproject.toml` files.
  * Updated build-system dependencies.
  * Restructured and standardised project metadata, entry-point declarations, and tool configuration formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->