### PR TITLE
Add Python 3.15 to the CI

### DIFF
--- a/.github/workflows/single-mongo.yml
+++ b/.github/workflows/single-mongo.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       python-versions:
         description: 'Supported python versions'
-        default: '["3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.11"]'
+        default: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.15", "pypy-3.11"]'
         required: false
         type: string
       mongo:
@@ -36,10 +36,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Install MongoDB
       uses: ankane/setup-mongodb@v1
       with:
@@ -49,7 +45,6 @@ jobs:
       uses: fizyk/actions-reuse/.github/actions/uv@67c2d834b83f6a05dd0d398d20d21b79f062d7fa # v5.2.2
       with:
         python-version: ${{ matrix.python-version }}
-
         command: python -m coverage run -m pytest -p no:xdist
         env: '{"COVERAGE_PROCESS_START": ".coveragerc", "COVERAGE_FILE": ".coverage.serial"}'
     - name: Combine and export serial coverage

--- a/.github/workflows/tests-oldest.yml
+++ b/.github/workflows/tests-oldest.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       python-versions:
         description: 'Supported python versions'
-        default: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+        default: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]'
         required: false
         type: string
       mongo:
@@ -35,10 +35,6 @@ jobs:
       MONGODB: ${{ inputs.mongo }}
     steps:
     - uses: actions/checkout@v7
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Install MongoDB
       uses: ankane/setup-mongodb@v1
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       mongo: 7.0
       os: ubuntu-22.04
-      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]'
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
   oldest:

--- a/newsfragments/+d5a4947a.misc.rst
+++ b/newsfragments/+d5a4947a.misc.rst
@@ -1,0 +1,1 @@
+Add Python 3.15 to CI


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded CI test coverage to include Python 3.15 alongside the existing supported versions.
* **Chores**
  * Simplified test workflow setup by streamlining Python environment preparation in CI.
  * Updated release notes content to reflect the new Python version in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->